### PR TITLE
One to one check

### DIFF
--- a/src/check.py
+++ b/src/check.py
@@ -25,6 +25,10 @@ def check_output(data: pd.DataFrame):
     coded_config = pd.read_csv('config/output_check/coded_values.csv')
     check_coded_values(data, coded_config)
 
+    # check for one to one relationships between two columns
+    check_columns_one_to_one(data, 'iso', 'country_territory_area')
+    check_columns_one_to_one(data, 'iso', 'who_region')
+    check_columns_one_to_one(data, 'iso', 'iso_3166_1_numeric')
 
     # check for unknown who_codes and iso_codes
     check_unknown_values(data, 'iso_3166_1_numeric')

--- a/src/check.py
+++ b/src/check.py
@@ -201,3 +201,35 @@ def check_coded_values(data: pd.DataFrame, config: pd.DataFrame, log: bool = Tru
                 logging.error('OUTPUT_CHECK_FAILURE=Unexpected values in %s: %s.' % (column_name, ', '.join([str(x) for x in difference])))
 
             pass
+
+
+def columns_one_to_one(data: pd.DataFrame, ref_col: str, target_col: str, log: bool = True):
+    '''
+    Function to detect violations of one-to-one relationships in a pair of columns.
+    '''
+
+    data = data.copy()
+
+    data = data[[ref_col, target_col]].drop_duplicates()
+
+    res = data.groupby([ref_col]).count()
+
+    res = list(res[target_col].unique())
+
+    try:
+
+        assert res == [1]
+
+        if log:
+
+            logging.info('OUTPUT_CHECK_SUCCESS=No one-to-one violations found between %s and %s.' % (ref_col, target_col))
+
+    except Exception as e:
+
+        if log:
+
+            logging.error('OUTPUT_CHECK_FAILURE=Violation of one-to-one relationship between %s and %s.' % (ref_col, target_col))
+
+        pass
+
+    return(res)

--- a/src/check.py
+++ b/src/check.py
@@ -203,7 +203,7 @@ def check_coded_values(data: pd.DataFrame, config: pd.DataFrame, log: bool = Tru
             pass
 
 
-def columns_one_to_one(data: pd.DataFrame, ref_col: str, target_col: str, log: bool = True):
+def check_columns_one_to_one(data: pd.DataFrame, ref_col: str, target_col: str, log: bool = True):
     '''
     Function to detect violations of one-to-one relationships in a pair of columns.
     '''

--- a/tests/test_shared_check.py
+++ b/tests/test_shared_check.py
@@ -43,3 +43,21 @@ class Test_check_values_present():
         res = check.check_values_present(data, 'focus_col', 'ref_col', log=False)
 
         assert not res
+
+class Test_check_columns_one_to_one:
+
+    def test_check_columns_one_to_one_present(self):
+
+        data = pd.DataFrame({'a':[1, 2, 3], 'b':['a', 'b', 'c']})
+
+        res = check.check_columns_one_to_one(data, 'a', 'b', log=False)
+
+        assert res == [1]
+
+    def test_check_columns_one_to_one_absent(self):
+
+        data = pd.DataFrame({'a':[1, 2, 2], 'b':['a', 'b', 'c']})
+
+        res = check.check_columns_one_to_one(data, 'a', 'b', log=False)
+
+        assert res == [1, 2]


### PR DESCRIPTION
Adds a check to flag if there is a violation of the one to one relationship between two column. 

Currently implemented for:

`iso` and `country_territory_area`
`iso` and `who_region`
`iso` and `iso_3166_1_numeric`