### PR TITLE
change country names

### DIFF
--- a/config/country_names/who_country_names.csv
+++ b/config/country_names/who_country_names.csv
@@ -113,11 +113,11 @@ WPRO,Japan,JPN,392
 EURO,Kazakhstan,KAZ,398
 EMRO,Jordan,JOR,400
 AFRO,Kenya,KEN,404
-SEARO,Democratic People'S Republic Of Korea,PRK,408
+SEARO,Democratic People's Republic Of Korea,PRK,408
 WPRO,Republic Of Korea,KOR,410
 EMRO,Kuwait,KWT,414
 EURO,Kyrgyzstan,KGZ,417
-WPRO,Lao People'S Democratic Republic,LAO,418
+WPRO,Lao People's Democratic Republic,LAO,418
 EMRO,Lebanon,LBN,422
 AFRO,Lesotho,LSO,426
 EURO,Latvia,LVA,428


### PR DESCRIPTION
The Excel `PROPER` function has odd behaviour with `'s` - returning `'S`. This is not the behaviour of other string to title functions. 

Changes country names to resolve this error.