### PR TITLE
Lower case columns

### DIFF
--- a/src/manually_cleaned.py
+++ b/src/manually_cleaned.py
@@ -15,7 +15,7 @@ import logging
 from utils import create_dir, log_records_per, log_records_total
 from postprocess.main import postprocess
 from check import check_output
-from manually_cleaned.main import adjust_manually_cleaned
+from manually_cleaned.main import adjust_manually_cleaned, columns_to_lower
 
 argv = sys.argv
 
@@ -27,6 +27,14 @@ logging.basicConfig(filename='tmp/manually_cleaned/manually_cleaned.log',
 
 print("Reading manually cleaned data...")
 logging.info("Reading manually cleaned data...")
+
+lowercase_columns = ['admin_level',
+                     'enforcement',
+                     'keep',
+                     'measure_stage',
+                     'non_compliance_penalty',
+                     'processed',
+                     'reason_ended']
 
 manually_cleaned = pd.read_csv('data/cleansed/mistress_latest.csv', low_memory=False,
     dtype={'date_start':str, 'date_end':str, 'date_entry':str})

--- a/src/manually_cleaned.py
+++ b/src/manually_cleaned.py
@@ -56,6 +56,8 @@ manually_cleaned = adjust_manually_cleaned(manually_cleaned)
 manually_cleaned.loc[(pd.isna(manually_cleaned['keep'])) & ([x in ['10', '11', '12', '13'] for x in manually_cleaned['who_code']]), 'keep'] = 'n'
 manually_cleaned.loc[(pd.isna(manually_cleaned['keep'])) & ([x not in ['10', '11', '12', '13'] for x in manually_cleaned['who_code']]), 'keep'] = 'y'
 
+manually_cleaned = columns_to_lower(manually_cleaned, lowercase_columns)
+
 # Check mistress
 check_output(manually_cleaned)
 

--- a/src/manually_cleaned/main.py
+++ b/src/manually_cleaned/main.py
@@ -67,3 +67,21 @@ def update_measure_stage_date(manually_cleaned):
     manually_cleaned.loc[(is_null_date_end) & (is_finish), "date_end"] = manually_cleaned.loc[(is_null_date_end) & (is_finish), "date_start"]
 
     return(manually_cleaned)
+
+
+def columns_to_lower(manually_cleaned: pd.DataFrame, lowercase_columns: list):
+    '''Function to set all columns to lowercase'''
+
+    for col in lowercase_columns:
+
+        try:
+
+            assert all(isinstance(x, str) for x in manually_cleaned[col] if not pd.isna(x))
+
+        except AssertionError:
+
+            raise AssertionError('Column {} does not only contain strings'.format(col))
+
+        manually_cleaned[col] = manually_cleaned[col].str.lower()
+
+    return(manually_cleaned)

--- a/tests/manually_cleaned/test_manually_cleaned.py
+++ b/tests/manually_cleaned/test_manually_cleaned.py
@@ -66,3 +66,30 @@ class Test_update_measure_stage_date():
 
         assert res.loc[0, 'date_end'] == None
         assert res.loc[0, 'reason_ended'] == None
+
+
+class Test_columns_to_lower:
+
+    def test_columns_to_lower_string(self):
+
+        manually_cleaned = pd.DataFrame({'a':['A', 'B', 'Something']})
+
+        res = main.columns_to_lower(manually_cleaned, ['a'])
+
+        assert len(set(res['a']).difference(set(['a', 'b', 'something']))) == 0
+
+    def test_columns_to_lower_none(self):
+
+        manually_cleaned = pd.DataFrame({'a':['A', 'B', None]})
+
+        res = main.columns_to_lower(manually_cleaned, ['a'])
+
+        assert len(set(res['a']).difference(set(['a', 'b', None]))) == 0
+
+    def test_columns_to_lower_mixed(self):
+
+        manually_cleaned = pd.DataFrame({'a':['A', 1, None]})
+
+        with pytest.raises(AssertionError):
+
+            main.columns_to_lower(manually_cleaned, ['a'])


### PR DESCRIPTION
Correctly coded values with incorrect capitalisation have been raising unneeded errors. 

Here, these columns will be converted to lowercase when reading in manually cleaned data. 

Added a check that all column values are either null or a string instance before converting to lower case. 