### PR TITLE
Add new line to manually change United States Virgin Islands country name

### DIFF
--- a/src/processing/OXCGRT.py
+++ b/src/processing/OXCGRT.py
@@ -59,6 +59,7 @@ def transform(record: dict, key_ref: dict, country_ref: pd.DataFrame, who_coding
 
     # 7. Make manual country name changes
     record = utils.replace_conditional(record, 'country_territory_area', 'Virgin Islands', 'US Virgin Islands')
+    record = utils.replace_conditional(record, 'country_territory_area', 'United States Virgin Islands', 'US Virgin Islands')
     record = utils.replace_conditional(record, 'country_territory_area', 'Eswatini', 'Swaziland')
     record = utils.replace_conditional(record, 'country_territory_area', 'South Korea', 'Korea')
 


### PR DESCRIPTION
`countrycode` library assign USA ISO code to country name with `United States Virgin Islands`,  but assign the correct ISO code to country name `US Virgin Islands`. All records with `United States Virgin Islands` country name are thus returned as USA. Add a new line to `OXCGRT.py` that manually change`United States Virgin Islands` to `US Virgin Islands` as a temporary fix for oxford records.

